### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bgruening @cbrueffer @conda-forge/r @croth1 @daler @dbast @jdblischak @johanneskoester
+* @conda-forge/r @croth1

--- a/README.md
+++ b/README.md
@@ -115,12 +115,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@bgruening](https://github.com/bgruening/)
-* [@cbrueffer](https://github.com/cbrueffer/)
 * [@conda-forge/r](https://github.com/conda-forge/r/)
 * [@croth1](https://github.com/croth1/)
-* [@daler](https://github.com/daler/)
-* [@dbast](https://github.com/dbast/)
-* [@jdblischak](https://github.com/jdblischak/)
-* [@johanneskoester](https://github.com/johanneskoester/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,9 +51,3 @@ extra:
   recipe-maintainers:
     - conda-forge/r
     - croth1
-    - johanneskoester
-    - bgruening
-    - daler
-    - jdblischak
-    - cbrueffer
-    - dbast


### PR DESCRIPTION

Remove individually listed maintainers that are members of the conda-forge/r team

Followed a similar strategy from the docs for updating the maintainers. Unfortunately it doesn't appear possible to skip the CI jobs in the PR itself, even the example PR had jobs run

https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list
